### PR TITLE
Add Potsdam segmentation example

### DIFF
--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -1,5 +1,6 @@
 FROM raster-vision-cpu
 
 COPY ./spacenet /opt/src/spacenet
+COPY ./potsdam /opt/src/potsdam
 
 CMD ["bash"]

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,5 +1,6 @@
 FROM raster-vision-gpu
 
 COPY ./spacenet /opt/src/spacenet
+COPY ./potsdam /opt/src/potsdam
 
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository holds examples for Raster Vision usage on open datasets.
 Table of Contents:
 - [Setup and Requirements](#setup-and-requirements)
 - [SpaceNet Building Chip Classification](#spacenet-building-chip-classification)
+- [ISPRS Potsdam Semantic Segmentation](#isprs-potsdam-semantic-segmentation)
 
 ## Setup and Requirements
 
@@ -68,7 +69,7 @@ We can inspect results quickly by installing the [QGIS plugin](https://github.co
 
 ## Spacenet Building Chip Classification
 
-This example performs chip classification to detect buildings in the SpaceNet imagery.
+This example performs chip classification to detect buildings in the [SpaceNet](https://spacenetchallenge.github.io/) imagery.
 It is set up to train on the Rio dataset.
 
 ### Step 1: Run the Jupyter Notebook
@@ -160,3 +161,104 @@ A walkthrough of using QGIS to inspect these results can be found [in the QGIS p
 Viewing the validation scene results for scene ID `013022232023` looks like this:
 
 ![QGIS results explorer](img/qgis-spacenet-cc.png)
+
+## ISPRS Potsdam Semantic Segmentation
+
+This example performs semantic segmentation on the [ISPRS Potsdam dataset](http://www2.isprs.org/commissions/comm3/wg4/2d-sem-label-potsdam.html). The dataset consists of 5cm aerial imagery over Potsdam, Germany, segmented into six classes including building, tree, low vegetation, impervious, car, and clutter. For more info see our [blog post](https://www.azavea.com/blog/2017/05/30/deep-learning-on-aerial-imagery/).
+
+### Step 1: Download the dataset
+
+The dataset can only be downloaded after filling in this [request form](http://www2.isprs.org/commissions/comm3/wg4/data-request-form2.html). After your request is granted, follow the link to 'POTSDAM 2D LABELING' and download and unzip `1_DSM_normalisation.zip`, `4_Ortho_RGBIR.zip`, and `5_Labels_for_participants.zip` into `data/`.
+
+### Step 2: Run experiment
+
+The experiment we want to run is in `potsdam/semantic_segmentation.py`. This runs a Mobilenet using the Tensorflow Deeplab backend for 100k steps, which takes about six hours to train on an AWS P3 instance.
+
+To do a small test run locally to check that things are setup properly, invoke
+```
+> rastervision run local -e potsdam.semantic_segmentation \
+    -a test_run True -a root_uri ${ROOT_URI} -a data_uri ${DATA_URI}
+```
+This only trains the model for one step, so the predictions will be random.
+
+To run a full experiment on AWS Batch, upload the data to S3, set `ROOT_URI` and `DATA_URI` to S3 URIs, and invoke
+```
+> rastervision run aws_batch -e potsdam.semantic_segmentation \
+    -a root_uri ${ROOT_URI} -a data_uri ${DATA_URI}
+```
+
+### Step 3: Inspect Evaluation results
+
+After running for around 6 hours on a P3 instance, you should have the following evaluation results in `${DATA_URI}/eval/potsdam-seg/eval.json`
+
+```javascript
+[
+    {
+        "precision": 0.8656729563616176,
+        "gt_count": 1746655,
+        "class_id": 1,
+        "recall": 0.8081258176342782,
+        "count_error": 200350.09143477102,
+        "class_name": "Car",
+        "f1": 0.8351868892794376
+    },
+    {
+        "precision": 0.9077043151132905,
+        "gt_count": 28166583,
+        "class_id": 2,
+        "recall": 0.9453450210840271,
+        "count_error": 1496358.1113330645,
+        "class_name": "Building",
+        "f1": 0.9259374145605163
+    },
+    {
+        "precision": 0.8105826727015737,
+        "gt_count": 30140893,
+        "class_id": 3,
+        "recall": 0.8826813459043832,
+        "count_error": 3813131.239710051,
+        "class_name": "Low Vegetation",
+        "f1": 0.8448803483993653
+    },
+    {
+        "precision": 0.8853166963497794,
+        "gt_count": 16928529,
+        "class_id": 4,
+        "recall": 0.7333917790494379,
+        "count_error": 2298428.025324646,
+        "class_name": "Tree",
+        "f1": 0.798672495115001
+    },
+    {
+        "precision": 0.8905422564785969,
+        "gt_count": 29352493,
+        "class_id": 5,
+        "recall": 0.8771725795147962,
+        "count_error": 2346809.6169586345,
+        "class_name": "Impervious",
+        "f1": 0.883793546499612
+    },
+    {
+        "precision": 0.40612390917761676,
+        "gt_count": 1664847,
+        "class_id": 6,
+        "recall": 0.3042724046113547,
+        "count_error": 759642.5306962142,
+        "class_name": "Clutter",
+        "f1": 0.3474061991276365
+    },
+    {
+        "precision": 0.8640141242953602,
+        "gt_count": 108000000,
+        "class_id": null,
+        "recall": 0.8640043796296297,
+        "count_error": 2467470.602260491,
+        "class_name": "average",
+        "f1": 0.8615277511625675
+    }
+]
+```
+
+### Step 4: View results through QGIS plugin
+
+TODO

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You'll need `docker` (preferably version 18 or above) installed.
 
 ### Setup
 
-To build the examples container, run the following make command:
+To build the examples container, run the following command:
 
 ```shell
 > scripts/build
@@ -22,11 +22,11 @@ To build the examples container, run the following make command:
 
 This will pull down the latest `raster-vision` docker and add some of this repo's code to it.
 
-__Note__: Pre-release, you'll need to build Raster Vision locally for this build step to work.
+__Note__: Pre-release, you'll need to build Raster Vision locally for this build step to work. (ie. run `./scripts/update` in `raster-vision`)
 
 ### Running the console
 
-Whenever the instructions say to "run the console", it meants to spin up an image and drop into a bash shell by doing this:
+Whenever the instructions say to "run the console", it means to spin up an image and drop into a bash shell by doing this:
 
 ```shell
 > scripts/console
@@ -47,7 +47,7 @@ Whenever intructions say to "run jupyter", it means to run the JupyterHub instan
 > scripts/jupyter
 ```
 
-This mounts many of the same directories as `scripts/consle`. The terminal output will give you the URL to go to in order to JupyterHub.
+This mounts many of the same directories as `scripts/consle`. The terminal output will give you the URL to go to in order to use JupyterHub.
 
 ### Running against AWS
 
@@ -64,7 +64,7 @@ job_definition=raster-vision-gpu-newapi
 
 ### QGIS Plugin
 
-We can inspect results quickly by installing the [QGIS plugin](https://github.com/azavea/raster-vision-aws). This is an optional step, and requires QGIS 3. See that repository's README for more installation instructions.
+We can inspect results quickly by installing the [QGIS plugin](https://github.com/azavea/raster-vision-qgis). This is an optional step, and requires QGIS 3. See that repository's README for more installation instructions.
 
 ## Spacenet Building Chip Classification
 

--- a/potsdam/semantic_segmentation.py
+++ b/potsdam/semantic_segmentation.py
@@ -1,0 +1,123 @@
+import os
+
+import rastervision as rv
+
+
+def build_scene(task, data_uri, id, channel_order=None):
+    id = id.replace('-', '_')
+    raster_source_uri = '{}/4_Ortho_RGBIR/top_potsdam_{}_RGBIR.tif'.format(
+        data_uri, id)
+
+    label_source_uri = '{}/5_Labels_for_participants/top_potsdam_{}_label.tif'.format(
+        data_uri, id)
+
+    label_source = rv.LabelSourceConfig.builder(rv.SEMANTIC_SEGMENTATION_RASTER) \
+        .with_source_class_map(task.class_map) \
+        .with_raster_source(label_source_uri) \
+        .build()
+
+    scene = rv.SceneConfig.builder() \
+                          .with_task(task) \
+                          .with_id(id) \
+                          .with_raster_source(raster_source_uri,
+                                              channel_order=channel_order) \
+                          .with_label_source(label_source) \
+                          .build()
+
+    return scene
+
+
+class PotsdamSemanticSegmentation(rv.ExperimentSet):
+    def exp_main(self, root_uri, data_uri, test_run=False):
+        """Run an experiment on the ISPRS Potsdam dataset.
+
+        Uses Tensorflow Deeplab backend with Mobilenet architecture. Should get to
+        F1 score of ~0.86 (including clutter class) after 6 hours of training on P3
+        instance.
+
+        Args:
+            root_uri: (str) root directory for experiment output
+            data_uri: (str) root directory of Potsdam dataset
+            test_run: (bool) if True, run a very small experiment as a test and generate
+                debug output
+        """
+        if test_run == 'True':
+            test_run = True
+        elif test_run == 'False':
+            test_run = False
+
+        train_ids = ['2-10', '2-11', '3-10', '3-11', '4-10', '4-11', '4-12', '5-10',
+                     '5-11', '5-12', '6-10', '6-11', '6-7', '6-9', '7-10', '7-11',
+                     '7-12', '7-7', '7-8', '7-9']
+        val_ids = ['2-12', '3-12', '6-12']
+        # infrared, red, green
+        channel_order = [3, 0, 1]
+
+        debug = False
+        batch_size = 16
+        number_of_chips = 500
+        num_steps = 100000
+        model_type = rv.MOBILENET_V2
+
+        # Better results can be obtained at a greater computational expense using
+        # num_steps = 150000
+        # model_type = rv.XCEPTION_65
+
+        if test_run:
+            debug = True
+            num_steps = 1
+            batch_size = 1
+            number_of_chips = 1
+            train_ids = train_ids[0:1]
+            val_ids = val_ids[0:1]
+
+        classes = {
+            'Car': (1, '#ffff00'),
+            'Building': (2, '#0000ff'),
+            'Low Vegetation': (3, '#00ffff'),
+            'Tree': (4, '#00ff00'),
+            'Impervious': (5, "#ffffff"),
+            'Clutter': (6, "#ff0000")
+        }
+
+        task = rv.TaskConfig.builder(rv.SEMANTIC_SEGMENTATION) \
+                            .with_chip_size(256) \
+                            .with_classes(classes) \
+                            .with_chip_options(
+                                number_of_chips=number_of_chips,
+                                debug_chip_probability=0.2,
+                                negative_survival_probability=1.0) \
+                            .build()
+
+        backend = rv.BackendConfig.builder(rv.TF_DEEPLAB) \
+                                  .with_task(task) \
+                                  .with_model_defaults(model_type) \
+                                  .with_train_options(sync_interval=600) \
+                                  .with_num_steps(num_steps) \
+                                  .with_batch_size(batch_size) \
+                                  .with_debug(debug) \
+                                  .build()
+
+        train_scenes = [build_scene(task, data_uri, id, channel_order)
+                        for id in train_ids]
+        val_scenes = [build_scene(task, data_uri, id, channel_order)
+                      for id in val_ids]
+
+        dataset = rv.DatasetConfig.builder() \
+                                  .with_train_scenes(train_scenes) \
+                                  .with_validation_scenes(val_scenes) \
+                                  .build()
+
+        experiment = rv.ExperimentConfig.builder() \
+                                        .with_id('potsdam-seg') \
+                                        .with_task(task) \
+                                        .with_backend(backend) \
+                                        .with_dataset(dataset) \
+                                        .with_root_uri(root_uri) \
+                                        .build()
+
+        return experiment
+
+
+if __name__ == '__main__':
+    rv.main()

--- a/scripts/console
+++ b/scripts/console
@@ -26,6 +26,7 @@ then
 
     docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} ${RV_CONFIG} \
            -v "$SRC"/spacenet:/opt/src/spacenet \
+           -v "$SRC"/potsdam:/opt/src/potsdam \
            -v "$SRC"/notebooks:/opt/notebooks \
            -v "$SRC"/data:/opt/data \
            ${IMAGE} "${@:1}"


### PR DESCRIPTION
This PR adds an example of running semantic segmentation on the Potsdam dataset. We will need to fill in the QGIS section after segmentation is working. I think we can also do some editing across all the examples to standardize and extract common content.