### PR TITLE
Add "developer mode" modifications

### DIFF
--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -1,4 +1,5 @@
-FROM quay.io/azavea/raster-vision:cpu-0.8
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 
 COPY ./spacenet /opt/src/spacenet
 COPY ./potsdam /opt/src/potsdam

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -1,4 +1,5 @@
-FROM quay.io/azavea/raster-vision:gpu-0.8
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
 
 COPY ./spacenet /opt/src/spacenet
 COPY ./potsdam /opt/src/potsdam

--- a/README.md
+++ b/README.md
@@ -38,9 +38,18 @@ Whenever the instructions say to "run the console", it means to spin up an image
 This will mount the following directories:
 - `${HOME}/.aws` -> `/root/.aws`
 - `${HOME}/.rastervision` -> `/root/.rastervision`
-- `spacenet` -> `/opt/src/spacenet`
 - `notebooks` -> `/opt/notebooks`
 - `data` -> `/opt/data`
+- `spacenet` -> `/opt/src/spacenet`
+- `potsdam` -> `/opt/src/potsdam`
+- `xview` -> `/opt/src/xview`
+- `cowc` -> `/opt/src/cowc`
+
+### "Developer Mode"
+
+It can be helpful for debugging purposes to use a local copy of Raster Vision rather than the version baked into the default Docker image (the latest version on Quay). To do this, you can set the `RASTER_VISION_REPO` environment variable to the location of the Raster Vision repo on your local filesystem. If this is set, the `build` script will set the base image to `raster-vision-{cpu,gpu}`. The `console` script will also mount `$RASTER_VISION_REPO/rastervision` to `/opt/src/rastervision` inside the container. You can then set breakpoints in your local copy of Raster Vision in order to debug experiments run inside the container.
+
+In addition, if you would like to mount a custom data directory on your local filesystem into the container, you can set the `RASTER_VISION_DATA_DIR` environment variable before running the `console` script.
 
 ### Running Raster Vision
 

--- a/scripts/build
+++ b/scripts/build
@@ -20,10 +20,24 @@ then
 
     if [ $# -eq 0 -o "${1:-}" = "--cpu" ]
     then
-        docker build -t raster-vision-examples-cpu -f Dockerfile-cpu .
+        if [ -z "$RASTER_VISION_REPO" ]
+        then
+            BASE_IMAGE="quay.io/azavea/raster-vision:cpu-0.8"
+        else
+            BASE_IMAGE="raster-vision-cpu"
+        fi
+
+        docker build --build-arg BASE_IMAGE="$BASE_IMAGE" -t raster-vision-examples-cpu -f Dockerfile-cpu .
     fi
     if [ $# -eq 0 -o "${1:-}" = "--gpu" ]
     then
-        docker build -t raster-vision-examples-gpu -f Dockerfile-gpu .
+        if [ -z "$RASTER_VISION_REPO" ]
+        then
+            BASE_IMAGE="quay.io/azavea/raster-vision:gpu-0.8"
+        else
+            BASE_IMAGE="raster-vision-gpu"
+        fi
+
+        docker build --build-arg BASE_IMAGE="$BASE_IMAGE" -t raster-vision-examples-gpu -f Dockerfile-gpu .
     fi
 fi

--- a/scripts/console
+++ b/scripts/console
@@ -5,8 +5,7 @@ set -e
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
 SCRIPTS_DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-PROJECT_ROOT="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
-SRC="${PROJECT_ROOT}"
+REPO_ROOT="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
 
 function usage() {
     echo -n \
@@ -17,6 +16,14 @@ All arguments are passed to 'docker run'.
 }
 
 IMAGE="raster-vision-examples-cpu"
+DATA_DIR="${RASTER_VISION_DATA_DIR:-${REPO_ROOT}/data}"
+
+if [ -z "$RASTER_VISION_REPO" ]
+then
+    SRC_FLAGS=""
+else
+    SRC_FLAGS="-v ${RASTER_VISION_REPO}/rastervision:/opt/src/rastervision"
+fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
@@ -25,11 +32,11 @@ then
     RV_CONFIG="-v ${HOME}/.rastervision:/root/.rastervision:ro"
 
     docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} ${RV_CONFIG} \
-           -v "$SRC"/spacenet:/opt/src/spacenet \
-           -v "$SRC"/potsdam:/opt/src/potsdam \
-	   -v "$SRC"/xview:/opt/src/xview \
-           -v "$SRC"/cowc:/opt/src/cowc \
-           -v "$SRC"/notebooks:/opt/notebooks \
-           -v "$SRC"/data:/opt/data \
+           -v "$REPO_ROOT"/spacenet:/opt/src/spacenet \
+           -v "$REPO_ROOT"/potsdam:/opt/src/potsdam \
+	       -v "$REPO_ROOT"/xview:/opt/src/xview \
+           -v "$REPO_ROOT"/cowc:/opt/src/cowc \
+           -v "$REPO_ROOT"/notebooks:/opt/notebooks \
+           ${SRC_FLAGS} -v "$DATA_DIR":/opt/data \
            ${IMAGE} "${@:1}"
 fi


### PR DESCRIPTION
This PR makes it easier for someone to put breakpoints, etc. in a local copy of RV and have that reflected in the Docker container, and point to a custom data directory. See README update for details. 

I tested this by setting `RASTER_VISION_DATA_DIR` and `RASTER_VISION_REPO` and running `build` and `console`, and then unsetting them and repeating.

Connects #16 
