### PR TITLE
Add model zoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository holds examples for Raster Vision usage on open datasets.
 
 Table of Contents:
 - [Setup and Requirements](#setup-and-requirements)
+- [Model Zoo](#model-zoo)
 - [SpaceNet Rio Building Chip Classification](#spacenet-rio-building-chip-classification)
 - [Spacenet Vegas Roads and Buildings: All Tasks](#spacenet-vegas)
 - [ISPRS Potsdam Semantic Segmentation](#isprs-potsdam-semantic-segmentation)
@@ -94,6 +95,27 @@ During the training step of experiments that have backends that support
 [Tensorboard](https://github.com/tensorflow/tensorboard), you should be able to view Tensorboard
 at either `localhost:6006/` if you are running locally, or `<public_dns>:6006` if you are running
 on AWS, where `<public_dns>` is the pulbic DNS of the instance that is running the training job.
+
+## Model Zoo
+
+| Dataset | Task | Model | Prediction Package | Sample Image | Model (for fine-tuning) |
+| --- | --- | --- | --- | --- | --- |
+| Spacenet Rio Buildings | Chip Classification | Resnet50 | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/rio-cc/predict_package.zip) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/rio-cc/013022223130_sample.tif) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/rio-cc/model-weights.hdf5) |
+| Spacenet Vegas Buildings | Semantic Segmentation | Mobilenet | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/vegas-building-seg/predict_package.zip) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/vegas-building-seg/1929.tif) | n/a |
+| Spacenet Vegas Roads | Semantic Segmentation | Mobilenet | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/vegas-road-seg/predict_package.zip) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/vegas-road-seg/524.tif) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/vegas-road-seg/roads-mobilenet.tar.gz) |
+| ISPRS Potsdam | Semantic Segmentation | Mobilenet | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/potsdam-seg/predict_package.zip) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/potsdam-seg/3_12_sample.tif) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/potsdam-seg/model.tar.gz) |
+| COWC Potsdam (Cars) | Object Detection | Mobilenet | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/cowc-od/predict_package.zip) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/cowc-od/3_10_sample.tif) | n/a |
+| xView Vehicle | Object Detection | Mobilenet | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/xview-vehicle-od/predict_package.zip) | [link](https://s3.amazonaws.com/azavea-research-public-data/raster-vision/examples/model-zoo/xview-vehicle-od/1677.tif) | n/a |
+
+Using the Model Zoo, you can download prediction packages which contain pre-trained models and configuration, and then run them on sample test images that the model wasn't trained on.
+
+```shell
+> rastervision predict <predict_package> <infile> <outfile>
+```
+
+It shouldn't take more than a minute on a CPU to make predictions for each sample. For some of the examples, there are also model files that can be used for fine-tuning on another dataset.
+
+**Disclaimer**: These models are provided for testing and demonstration purposes and aren't particularly accurate. As is usually the case for deep learning models, the accuracy drops greatly when used on input that is outside the training distribution. In other words, a model trained in one city probably won't work well in another city (unless they are very similar) or at a different imagery resolution.
 
 ## Spacenet Rio Building Chip Classification
 


### PR DESCRIPTION
This PR adds a model zoo with predict packages for each example. I checked that the links aren't broken and are correct.

Here's where the predict packages came from:
* s3://raster-vision-rob-dev/spacenet/cc/bundle/spacenet-rio-chip-classification/predict_package.zip
* s3://raster-vision-lf-dev/rv-output/vegas-spacenet-seg/bundle/buildings/predict_package.zip
* s3://raster-vision-lf-dev/rv-output/vegas-spacenet-seg/bundle/roads-mobilenet/predict_package.zip
* s3://raster-vision-lf-dev/rv-output/potsdam-seg/bundle/potsdam-seg-batch8/predict_package.zip
* s3://raster-vision-rob-dev/cowc/od/bundle/cowc-object-detection-full/predict_package.zip
* s3://raster-vision-rob-dev/xview/od/bundle/xview-object-detection-mobilenet/predict_package.zip

Closes #14 