### PR TITLE
Add `other` directory

### DIFF
--- a/Dockerfile-cpu
+++ b/Dockerfile-cpu
@@ -5,5 +5,6 @@ COPY ./spacenet /opt/src/spacenet
 COPY ./potsdam /opt/src/potsdam
 COPY ./xview /opt/src/xview
 COPY ./cowc  /opt/src/cowc
+COPY ./other  /opt/src/other
 
 CMD ["bash"]

--- a/Dockerfile-gpu
+++ b/Dockerfile-gpu
@@ -5,5 +5,6 @@ COPY ./spacenet /opt/src/spacenet
 COPY ./potsdam /opt/src/potsdam
 COPY ./xview /opt/src/xview
 COPY ./cowc  /opt/src/cowc
+COPY ./other  /opt/src/other
 
 CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Table of Contents:
 - [COWC Potsdam Car Object Detection](#cowc-potsdam-car-object-detection)
 - [xView Vehicle Object Detection](#xview-vehicle-object-detection)
 
-
 ## Setup and Requirements
 
 ### Requirements
@@ -45,8 +44,9 @@ This will mount the following directories:
 - `potsdam` -> `/opt/src/potsdam`
 - `xview` -> `/opt/src/xview`
 - `cowc` -> `/opt/src/cowc`
+- `other` -> `/opt/src/other` (This directory is useful for holding Git repos containing examples you want to use with this Docker container.)
 
-### "Developer Mode"
+### Debug Mode
 
 It can be helpful for debugging purposes to use a local copy of Raster Vision rather than the version baked into the default Docker image (the latest version on Quay). To do this, you can set the `RASTER_VISION_REPO` environment variable to the location of the Raster Vision repo on your local filesystem. If this is set, the `build` script will set the base image to `raster-vision-{cpu,gpu}`. The `console` script will also mount `$RASTER_VISION_REPO/rastervision` to `/opt/src/rastervision` inside the container. You can then set breakpoints in your local copy of Raster Vision in order to debug experiments run inside the container.
 

--- a/other/.gitignore
+++ b/other/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/console
+++ b/scripts/console
@@ -36,6 +36,7 @@ then
            -v "$REPO_ROOT"/potsdam:/opt/src/potsdam \
 	       -v "$REPO_ROOT"/xview:/opt/src/xview \
            -v "$REPO_ROOT"/cowc:/opt/src/cowc \
+           -v "$REPO_ROOT"/other:/opt/src/other \
            -v "$REPO_ROOT"/notebooks:/opt/notebooks \
            ${SRC_FLAGS} -v "$DATA_DIR":/opt/data \
            ${IMAGE} "${@:1}"

--- a/scripts/jupyter
+++ b/scripts/jupyter
@@ -32,9 +32,10 @@ then
 
     docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} ${RV_CONFIG} \
            -v "$SRC"/spacenet:/opt/src/spacenet \
+           -v "$SRC"/potsdam:/opt/src/potsdam \
            -v "$SRC"/xview:/opt/src/xview \
            -v "$SRC"/cowc:/opt/src/cowc \
-           -v "$SRC"/potsdam:/opt/src/potsdam \
+           -v "$SRC"/other:/opt/src/other \
            -v "$SRC"/notebooks:/opt/notebooks \
            -v "$SRC"/data:/opt/data \
            -p 8080:8080 \


### PR DESCRIPTION
This PR adds an empty directory named `other` which is mounted like the other example directories. This is useful for allowing third party examples and experiments to utilize the scripts and Docker setup provided in this repo. If you have experiments in another Git repo, you just need to place the local copy of the repo in the `other` directory.

Closes #34