### PR TITLE
GPU-Related Script Improvements

### DIFF
--- a/scripts/console
+++ b/scripts/console
@@ -11,8 +11,7 @@ function usage() {
     echo -n \
          "Usage: $(basename "$0")
 Run a console in the raster-vision docker image locally.
---aws forwards AWS credentials.
---tensorboard maps port 6006
+--name sets the name of the running container
 --gpu use the NVIDIA runtime and GPU image
 All arguments after above options are passed to 'docker run'.
 "
@@ -27,16 +26,8 @@ while [[ $# -gt 0 ]]
 do
     key="$1"
     case $key in
-        --aws)
-        AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
-        shift # past argument
-        ;;
-        --tensorboard)
-        TENSORBOARD="-p 6006:6006"
-        shift # past argument
-        ;;
         --gpu)
-        IMAGE="raster-vision-gpu"
+        IMAGE="raster-vision-examples-gpu"
         RUNTIME="--runtime=nvidia"
         shift # past argument
         ;;
@@ -64,6 +55,8 @@ fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
+    AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
+    TENSORBOARD="-p 6006:6006"
     RV_CONFIG="-v ${HOME}/.rastervision:/root/.rastervision:ro"
 
     docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} ${RV_CONFIG} \

--- a/scripts/console
+++ b/scripts/console
@@ -10,12 +10,49 @@ REPO_ROOT="$( cd -P "$( dirname "$SCRIPTS_DIR" )" && pwd )"
 function usage() {
     echo -n \
          "Usage: $(basename "$0")
-Run console of docker image locally.
-All arguments are passed to 'docker run'.
+Run a console in the raster-vision docker image locally.
+--aws forwards AWS credentials.
+--tensorboard maps port 6006
+--gpu use the NVIDIA runtime and GPU image
+All arguments after above options are passed to 'docker run'.
 "
 }
 
 IMAGE="raster-vision-examples-cpu"
+
+# Parse options using scheme in
+# https://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+POSITIONAL=()
+while [[ $# -gt 0 ]]
+do
+    key="$1"
+    case $key in
+        --aws)
+        AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
+        shift # past argument
+        ;;
+        --tensorboard)
+        TENSORBOARD="-p 6006:6006"
+        shift # past argument
+        ;;
+        --gpu)
+        IMAGE="raster-vision-gpu"
+        RUNTIME="--runtime=nvidia"
+        shift # past argument
+        ;;
+        --name)
+        shift
+        NAME="--name $1"
+        shift
+        ;;
+        *)    # unknown option
+        POSITIONAL+=("$1") # save it in an array for later
+        shift # past argument
+        ;;
+    esac
+done
+set -- "${POSITIONAL[@]}" # restore positional parameters
+
 DATA_DIR="${RASTER_VISION_DATA_DIR:-${REPO_ROOT}/data}"
 
 if [ -z "$RASTER_VISION_REPO" ]
@@ -27,8 +64,6 @@ fi
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]
 then
-    AWS="-e AWS_PROFILE=${AWS_PROFILE:-default} -v ${HOME}/.aws:/root/.aws:ro"
-    TENSORBOARD="-p 6006:6006"
     RV_CONFIG="-v ${HOME}/.rastervision:/root/.rastervision:ro"
 
     docker run ${RUNTIME} ${NAME} --rm -it ${TENSORBOARD} ${AWS} ${RV_CONFIG} \


### PR DESCRIPTION
Some of the command-line parsing code from `raster-vision`'s `docker/console` script has been moved over.  The `--gpu` and `--name` flags are now supported.

Closes https://github.com/azavea/raster-vision/issues/594