### PR TITLE
add documentation to simple segmentation example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ var/
 .ipynb_checkpoints
 
 ./data/
+data/
+
+.vscode/*

--- a/examples/spacenet/vegas/simple_segmentation.py
+++ b/examples/spacenet/vegas/simple_segmentation.py
@@ -7,7 +7,14 @@ import rastervision as rv
 from rastervision.utils.files import list_paths
 from examples.utils import str_to_bool
 
+# Check out the docs for more information about the Raster Vision API:
+# https://docs.rastervision.io/en/0.9/index.html#documentation
 
+# Raster Vision ExperimentSets run similarly to the unittest.TestSuite. 
+# When you pass this script to the Raster Vision command line tool, it 
+# will reflexively run any ExperimentSet method that starts with 'exp_'.
+# Return ExperimentConfigs from these methods in order to kick off their
+# corresponding experiments.
 class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
     def exp_main(self, raw_uri, root_uri, test=False):
         """Run an experiment on the Spacenet Vegas building dataset.
@@ -21,23 +28,44 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
             test: (bool) if True, run a very small experiment as a test and generate
                 debug output
         """
+        # Specify the location of the raw data
         base_uri = join(
             raw_uri, 'SpaceNet_Buildings_Dataset_Round2/spacenetV2_Train/AOI_2_Vegas')
+        # The images and labels are in two separate directories within the base_uri
         raster_uri = join(base_uri, 'RGB-PanSharpen')
         label_uri = join(base_uri, 'geojson/buildings')
+        # The tiff (raster) and geojson (label) files have have a naming convention of
+        # '[prefix]_[image id].geojson.' The prefix indicates the type of data and the
+        # image id indicates which scene each is associated with.
         raster_fn_prefix = 'RGB-PanSharpen_AOI_2_Vegas_img'
         label_fn_prefix = 'buildings_AOI_2_Vegas_img'
+        # Find all of the image ids that have associated images and labels. Collect 
+        # these values to use as our scene ids.
         label_paths = list_paths(label_uri, ext='.geojson')
         label_re = re.compile(r'.*{}(\d+)\.geojson'.format(label_fn_prefix))
         scene_ids = [
             label_re.match(label_path).group(1)
             for label_path in label_paths]
 
-        test = str_to_bool(test)
+        # Set some trainin parameters:
+        # The exp_id will be the label associated with this experiment, it will be used
+        # to name the experiment config json.
         exp_id = 'spacenet-simple-seg'
+        # Number of times passing a batch of images through the model
         num_steps = 1e5
+        # Number of images in each batch
         batch_size = 8
+        # Specify whether or not to make debug chips (a zipped sample of png chips
+        # that you can examine to help debug the chipping process)
         debug = False
+
+        # This experiment includes an option to run a small test experiment before
+        # running the whole thing. You can set this using the 'test' parameter. If
+        # this parameter is set to True it will run a tiny test example with a new
+        # experiment id. This will be small enough to run locally. It is recommended
+        # to run a test example locally before submitting the whole experiment to AWs
+        # Batch.
+        test = str_to_bool(test)
         if test:
             exp_id += '-test'
             num_steps = 1
@@ -45,30 +73,49 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
             debug = True
             scene_ids = scene_ids[0:10]
 
+        # Split the data into training and validation sets:
+        # Randomize the order of all scene ids
         random.seed(5678)
         scene_ids = sorted(scene_ids)
         random.shuffle(scene_ids)
         # Workaround to handle scene 1000 missing on S3.
         if '1000' in scene_ids:
             scene_ids.remove('1000')
+        # Figure out how many scenes make up 80% of the whole set
         num_train_ids = round(len(scene_ids) * 0.8)
+        # Split the scene ids into training and validation lists
         train_ids = scene_ids[0:num_train_ids]
         val_ids = scene_ids[num_train_ids:]
 
+        # The TaskConfigBuilder constructs a child class of TaskConfig that
+        # corresponds to the type of computer vision task you are taking on.
+        # This experiment includes a semantic segmentation task but Raster
+        # Vision also has backends for object detection and chip classification.
+        # Before building the task config you can also set parameters using
+        # 'with_' methods. In the example below we set the chip size, the
+        # pixel class names and colors, and addiitonal chip options.
         task = rv.TaskConfig.builder(rv.SEMANTIC_SEGMENTATION) \
                             .with_chip_size(300) \
-                            .with_classes({
+                            .with_classes({  
                                 'Building': (1, 'orange'),
                                 'Background': (2, 'black')
                             }) \
-                            .with_chip_options(
+            .with_chip_options( 
                                 chips_per_scene=9,
                                 debug_chip_probability=0.25,
                                 negative_survival_probability=1.0,
                                 target_classes=[1],
                                 target_count_threshold=1000) \
-                            .build()
+            .build()
 
+        # Next we will create a backend that is built on top of a third-party
+        # deep learning library. In this case we will construct the 
+        # BackendConfig for DeepLab, which is the default semantic segmentation
+        # option for Raster Vision. We use 'with_' methods for additional
+        # configuration including the training parameters we specified above
+        # and the model defaults. Raster Vision has several different default
+        # architecture options for each task. They are stored in a JSON here:
+        # https://github.com/azavea/raster-vision/blob/60f741e30a016f25d2643a9b32916adb22e42d50/rastervision/backend/model_defaults.json
         backend = rv.BackendConfig.builder(rv.TF_DEEPLAB) \
                                   .with_task(task) \
                                   .with_model_defaults(rv.MOBILENET_V2) \
@@ -77,27 +124,55 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
                                   .with_debug(debug) \
                                   .build()
 
+        # We will use this function to create a list of scenes that we will pass
+        # to the DataSetConfig builder.
         def make_scene(id):
+            """Make a Scene object for each image/label pair
+
+            Args:
+                id (str): The id that corresponds to both the .tiff image source
+                    and .geojson label source for a given scene
+            
+            Returns:
+                rv.data.Scene: a Raster Vision Scene object which is composed of
+                    images, labels and optionally AOIs
+            """
+            # Find the uri for the image associated with this is
             train_image_uri = os.path.join(raster_uri,
                                            '{}{}.tif'.format(raster_fn_prefix, id))
 
+            # Construct a raster source from an image uri that can be handled by Rasterio.
+            # We also specify the order of image channels by their indices and add a 
+            # stats transformer which normalizes pixel values into uint8.
             raster_source = rv.RasterSourceConfig.builder(rv.RASTERIO_SOURCE) \
                 .with_uri(train_image_uri) \
                 .with_channel_order([0, 1, 2]) \
                 .with_stats_transformer() \
                 .build()
 
+            # Next create a label source config to pair with the raster source:
+            # define the geojson label source uri
             vector_source = os.path.join(
                 label_uri, '{}{}.geojson'.format(label_fn_prefix, id))
+            
+            # Since this is a semantic segmentation experiment, we need to rasterize
+            # our geojson. We create RasterSourceConfigBuilder using `rv.RASTERIZED_SOURCE`
+            # indicating that it will come from a vector source. We then specify the uri
+            # of the vector source and (in the 'with_rasterizer_options' method) the id
+            # of the pixel class we would like to use as background.
             label_raster_source = rv.RasterSourceConfig.builder(rv.RASTERIZED_SOURCE) \
                 .with_vector_source(vector_source) \
                 .with_rasterizer_options(2) \
                 .build()
 
+            # Create a semantic segmentation label source from rasterized source config
+            # that we built in the previous line.
             label_source = rv.LabelSourceConfig.builder(rv.SEMANTIC_SEGMENTATION) \
                 .with_raster_source(label_raster_source) \
                 .build()
 
+            # Finally we can build a scene config object using the scene id and the
+            # configs we just defined
             scene = rv.SceneConfig.builder() \
                 .with_task(task) \
                 .with_id(id) \
@@ -107,18 +182,29 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
 
             return scene
 
+        # Create lists of train and test scene configs
         train_scenes = [make_scene(id) for id in train_ids]
         val_scenes = [make_scene(id) for id in val_ids]
 
+        # Construct a DataSet config using the lists of train and
+        # validation scenes
         dataset = rv.DatasetConfig.builder() \
             .with_train_scenes(train_scenes) \
             .with_validation_scenes(val_scenes) \
             .build()
 
+        # We will need to convert this imagery from uint16 to uint8
+        # in order to use it. We specified that this conversion should take place
+        # when we built the train raster source but that process will require
+        # dataset-level statistics. To get these stats we need to create an 
+        # analyzer.
         analyzer = rv.AnalyzerConfig.builder(rv.STATS_ANALYZER) \
                                     .build()
 
-        # Need to use stats_analyzer because imagery is uint16.
+        # We use the previously-constructed configs to create the constituent
+        # parts of the experiment. We also give the builder strings that define
+        # the experiment id and and root uri. The root uri indicates where all
+        # of the output will be written.
         experiment = rv.ExperimentConfig.builder() \
                                         .with_id(exp_id) \
                                         .with_task(task) \
@@ -127,7 +213,8 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
                                         .with_dataset(dataset) \
                                         .with_root_uri(root_uri) \
                                         .build()
-
+        
+        # Return one or more experiment configs to run the experiment(s)
         return experiment
 
 

--- a/examples/spacenet/vegas/simple_segmentation.py
+++ b/examples/spacenet/vegas/simple_segmentation.py
@@ -10,8 +10,8 @@ from examples.utils import str_to_bool
 # Check out the docs for more information about the Raster Vision API:
 # https://docs.rastervision.io/en/0.9/index.html#documentation
 
-# Raster Vision ExperimentSets run similarly to the unittest.TestSuite. 
-# When you pass this script to the Raster Vision command line tool, it 
+# Raster Vision ExperimentSets run similarly to the unittest.TestSuite.
+# When you pass this script to the Raster Vision command line tool, it
 # will reflexively run any ExperimentSet method that starts with 'exp_'.
 # Return ExperimentConfigs from these methods in order to kick off their
 # corresponding experiments.
@@ -39,7 +39,7 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
         # image id indicates which scene each is associated with.
         raster_fn_prefix = 'RGB-PanSharpen_AOI_2_Vegas_img'
         label_fn_prefix = 'buildings_AOI_2_Vegas_img'
-        # Find all of the image ids that have associated images and labels. Collect 
+        # Find all of the image ids that have associated images and labels. Collect
         # these values to use as our scene ids.
         label_paths = list_paths(label_uri, ext='.geojson')
         label_re = re.compile(r'.*{}(\d+)\.geojson'.format(label_fn_prefix))
@@ -96,11 +96,11 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
         # pixel class names and colors, and addiitonal chip options.
         task = rv.TaskConfig.builder(rv.SEMANTIC_SEGMENTATION) \
                             .with_chip_size(300) \
-                            .with_classes({  
+                            .with_classes({
                                 'Building': (1, 'orange'),
                                 'Background': (2, 'black')
                             }) \
-            .with_chip_options( 
+            .with_chip_options(
                                 chips_per_scene=9,
                                 debug_chip_probability=0.25,
                                 negative_survival_probability=1.0,
@@ -109,7 +109,7 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
             .build()
 
         # Next we will create a backend that is built on top of a third-party
-        # deep learning library. In this case we will construct the 
+        # deep learning library. In this case we will construct the
         # BackendConfig for DeepLab, which is the default semantic segmentation
         # option for Raster Vision. We use 'with_' methods for additional
         # configuration including the training parameters we specified above
@@ -127,14 +127,14 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
         # We will use this function to create a list of scenes that we will pass
         # to the DataSetConfig builder.
         def make_scene(id):
-            """Make a Scene object for each image/label pair
+            """Make a SceneConfig object for each image/label pair
 
             Args:
                 id (str): The id that corresponds to both the .tiff image source
                     and .geojson label source for a given scene
-            
+
             Returns:
-                rv.data.Scene: a Raster Vision Scene object which is composed of
+                rv.data.SceneConfig: a SceneConfig object which is composed of
                     images, labels and optionally AOIs
             """
             # Find the uri for the image associated with this is
@@ -142,7 +142,7 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
                                            '{}{}.tif'.format(raster_fn_prefix, id))
 
             # Construct a raster source from an image uri that can be handled by Rasterio.
-            # We also specify the order of image channels by their indices and add a 
+            # We also specify the order of image channels by their indices and add a
             # stats transformer which normalizes pixel values into uint8.
             raster_source = rv.RasterSourceConfig.builder(rv.RASTERIO_SOURCE) \
                 .with_uri(train_image_uri) \
@@ -154,9 +154,11 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
             # define the geojson label source uri
             vector_source = os.path.join(
                 label_uri, '{}{}.geojson'.format(label_fn_prefix, id))
-            
-            # Since this is a semantic segmentation experiment, we need to rasterize
-            # our geojson. We create RasterSourceConfigBuilder using `rv.RASTERIZED_SOURCE`
+
+            # Since this is a semantic segmentation experiment and the labels
+            # are distributed in a vector-based GeoJSON format, we need to rasterize
+            # the labels. We create  aRasterSourceConfigBuilder using
+            # `rv.RASTERIZED_SOURCE`
             # indicating that it will come from a vector source. We then specify the uri
             # of the vector source and (in the 'with_rasterizer_options' method) the id
             # of the pixel class we would like to use as background.
@@ -196,7 +198,7 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
         # We will need to convert this imagery from uint16 to uint8
         # in order to use it. We specified that this conversion should take place
         # when we built the train raster source but that process will require
-        # dataset-level statistics. To get these stats we need to create an 
+        # dataset-level statistics. To get these stats we need to create an
         # analyzer.
         analyzer = rv.AnalyzerConfig.builder(rv.STATS_ANALYZER) \
                                     .build()
@@ -213,7 +215,7 @@ class SpacenetVegasSimpleSegmentation(rv.ExperimentSet):
                                         .with_dataset(dataset) \
                                         .with_root_uri(root_uri) \
                                         .build()
-        
+
         # Return one or more experiment configs to run the experiment(s)
         return experiment
 


### PR DESCRIPTION
I added comments to the Vegas simple segmentation example (https://github.com/azavea/raster-vision-examples/blob/master/examples/spacenet/vegas/simple_segmentation.py) to make it more of a tutorial. 

Let me know if you want me to make any changes.

Closes #40 